### PR TITLE
Update clippy3.rs

### DIFF
--- a/clippy/clippy3.rs
+++ b/clippy/clippy3.rs
@@ -5,7 +5,7 @@
 fn main() {
     let my_option: Option<()> = None;
     if my_option.is_none() {
-        println!("What't in my_option is: {:#?}", my_option.unwrap());
+        println!("What't in my_option is: {:#?}", my_option);
     }
 
     let my_arr = &[


### PR DESCRIPTION
my_option.unwrap() will panic from inside of println!(). Clippy is satisfied with this solution, but if you run you get a panic.